### PR TITLE
Update paho mqtt to v2 and add mqtt credentials

### DIFF
--- a/Polestar_2_MQTT.py
+++ b/Polestar_2_MQTT.py
@@ -19,8 +19,8 @@ TZ                      =     os.getenv('TZ')                       # z.B. 'Euro
 MQTT_BROKER             =     os.getenv("MQTT_BROKER",    "localhost")
 MQTT_PORT               = int(os.getenv("MQTT_PORT",      1883))
 MQTT_KEEPALIVE_INTERVAL = int(os.getenv("MQTT_KEEPALIVE", 60))
-MQTT_USER               = os.getenv("MQTT_USER")
-MQTT_PASSWORD           = os.getenv("MQTT_PASSWORD")
+MQTT_USER               =     os.getenv("MQTT_USER")
+MQTT_PASSWORD           =     os.getenv("MQTT_PASSWORD")
 
 BASE_TOPIC              =     os.getenv("BASE_TOPIC",     "polestar2")
 CLIENT_ID               =     "l3oopkc_10"
@@ -39,6 +39,7 @@ def on_disconnect(client, userdata, rc, properties, reason_code):
 
 # Verbindung zum MQTT Broker
 def connect_mqtt():   
+    # MQTT_USER und MQTT_PASSWORD muss leer bleiben, wenn kein Login am Broker
     client.username_pw_set(MQTT_USER, MQTT_PASSWORD)   
     client.on_connect = on_connect
     client.on_disconnect = on_disconnect

--- a/Polestar_2_MQTT.py
+++ b/Polestar_2_MQTT.py
@@ -31,15 +31,15 @@ client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2)
 def on_connect(client, userdata, flags, rc, properties):
     print("Connected with result code "+str(rc))
 
-def on_disconnect(client, userdata, rc):
+def on_disconnect(client, userdata, rc, properties, reason_code):
     if rc != 0:
         print("Unexpected disconnection.")
         # Reconnect
         client.reconnect()
 
 # Verbindung zum MQTT Broker
-def connect_mqtt():
-    client.username_pw_set(MQTT_USER, MQTT_PASSWORD)
+def connect_mqtt():   
+    client.username_pw_set(MQTT_USER, MQTT_PASSWORD)   
     client.on_connect = on_connect
     client.on_disconnect = on_disconnect
     client.connect(MQTT_BROKER, MQTT_PORT, MQTT_KEEPALIVE_INTERVAL)

--- a/Polestar_2_MQTT.py
+++ b/Polestar_2_MQTT.py
@@ -19,17 +19,16 @@ TZ                      =     os.getenv('TZ')                       # z.B. 'Euro
 MQTT_BROKER             =     os.getenv("MQTT_BROKER",    "localhost")
 MQTT_PORT               = int(os.getenv("MQTT_PORT",      1883))
 MQTT_KEEPALIVE_INTERVAL = int(os.getenv("MQTT_KEEPALIVE", 60))
+MQTT_USER               = os.getenv("MQTT_USER")
+MQTT_PASSWORD           = os.getenv("MQTT_PASSWORD")
 
 BASE_TOPIC              =     os.getenv("BASE_TOPIC",     "polestar2")
 CLIENT_ID               =     "l3oopkc_10"
-# TODO: MQTT-Credentials
 
 # MQTT-Client-Setup
-client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION1)
-# TODO: Migrate to MQTT-Client V2
-# https://github.com/eclipse/paho.mqtt.python/blob/v2.0.0/docs/migrations.rst
+client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2)
 
-def on_connect(client, userdata, flags, rc):
+def on_connect(client, userdata, flags, rc, properties):
     print("Connected with result code "+str(rc))
 
 def on_disconnect(client, userdata, rc):
@@ -40,6 +39,7 @@ def on_disconnect(client, userdata, rc):
 
 # Verbindung zum MQTT Broker
 def connect_mqtt():
+    client.username_pw_set(MQTT_USER, MQTT_PASSWORD)
     client.on_connect = on_connect
     client.on_disconnect = on_disconnect
     client.connect(MQTT_BROKER, MQTT_PORT, MQTT_KEEPALIVE_INTERVAL)

--- a/docker-compose_example.yml
+++ b/docker-compose_example.yml
@@ -13,6 +13,8 @@ services:
       POLESTAR_CYCLE:    300 # Sekunden
       MQTT_BROKER:       "192.168.1.100"
       MQTT_PORT:         "1883"
+      MQTT_USER:         ""
+      MQTT_PASSWORD:     ""
       BASE_TOPIC:        "polestar2"
 
 # ***** EOF *****

--- a/docker-compose_example.yml
+++ b/docker-compose_example.yml
@@ -13,8 +13,8 @@ services:
       POLESTAR_CYCLE:    300 # Sekunden
       MQTT_BROKER:       "192.168.1.100"
       MQTT_PORT:         "1883"
-      MQTT_USER:         ""
-      MQTT_PASSWORD:     ""
+      MQTT_USER:         "" # muss leer bleiben, wenn kein Login beim Broker erforderlich
+      MQTT_PASSWORD:     "" # s.o.
       BASE_TOPIC:        "polestar2"
 
 # ***** EOF *****


### PR DESCRIPTION
I changed the paho mqtt client to version 2 and added mqtt username & password. I tested it in my environment with my Polestar 2 and it works like a charm.